### PR TITLE
autoload command helm-descbinds

### DIFF
--- a/helm-descbinds.el
+++ b/helm-descbinds.el
@@ -244,6 +244,7 @@ This function called two argument KEY and BINDING."
     (candidates . ,candidates)
     ,@helm-descbinds-source-template))
 
+;;;###autoload
 (defun helm-descbinds (&optional prefix buffer)
   "Yet Another `describe-bindings' with `helm'."
   (interactive)


### PR DESCRIPTION
So that library helm-descbinds' only has to be loaded if the command is actually used. If the user chooses to depend on the autoload he has to bind the command manually.
