### PR TITLE
Set buffer name

### DIFF
--- a/helm-descbinds.el
+++ b/helm-descbinds.el
@@ -283,7 +283,8 @@ This function called two argument KEY and BINDING."
                                          helm-before-initialize-hook)))
     (setq helm-descbind--initial-full-frame old-helm-full-frame)
     (helm :sources (helm-descbinds-sources
-                    (or buffer (current-buffer)) prefix))))
+                    (or buffer (current-buffer)) prefix)
+          :buffer "*helm-descbinds*")))
 
 (provide 'helm-descbinds)
 


### PR DESCRIPTION
This sets a specific buffer name for helm-descbinds. It would be useful to be able to discriminate the buffer.
In my case, I would like to use helm-descbinds with https://github.com/m2ym/popwin-el, in which determines which buffer to operate on by buffer name.
