### PR TITLE
Highlight matches in helm buffer

### DIFF
--- a/helm-descbinds.el
+++ b/helm-descbinds.el
@@ -5,6 +5,7 @@
 ;; Copyright (C) 2013 Daniel Hackney <dan@haxney.org>
 
 ;; Author: Taiki SUGAWARA <buzz.taiki@gmail.com>
+;; URL: https://github.com/emacs-helm/helm-descbinds
 ;; Keywords: helm, help
 ;; Version: 1.08
 ;; Package-Requires: ((helm "1.5"))

--- a/helm-descbinds.el
+++ b/helm-descbinds.el
@@ -138,6 +138,7 @@ This function called two argument KEY and BINDING."
 
 (defcustom helm-descbinds-source-template
   `((candidate-transformer . helm-descbinds-transform-candidates)
+    (filtered-candidate-transformer . helm-fuzzy-highlight-matches)
     (persistent-action . helm-descbinds-action:describe)
     (action . ,helm-descbinds-actions))
   "A template of `helm-descbinds' source."


### PR DESCRIPTION
I'd like to see `helm-input` gets highlighted by default in helm completion buffer, just like many other helm commands. This PR tries to do that and it works as my expect, but I am not sure if this is the best way (I am not familiar with helm internal very much).