### PR TITLE
Use `helm-describe-function-function` for a help

### DIFF
--- a/helm-descbinds.el
+++ b/helm-descbinds.el
@@ -224,7 +224,7 @@ see (info \"(elisp) Prefix Keys\").")
        (helm-descbinds-display-string-in-help
         helm-descbinds-prefix-help))
       ((guard (and (symbolp name) (fboundp name)))
-       (describe-function name)))))
+       (funcall helm-describe-function-function name)))))
 
 (defun helm-descbinds-action:find-func (candidate)
   "An action that find selected CANDIDATE function."


### PR DESCRIPTION
This allow to use the same function to describe function as other helm functions
, i.e. `helm-M-x`.

I find it useful to use with `helpful` package, while retaining existing functionality.